### PR TITLE
Refactor: Rename console application components for better consistency

### DIFF
--- a/sandboxes/ConsoleSandbox/Commands/ListCommand.cs
+++ b/sandboxes/ConsoleSandbox/Commands/ListCommand.cs
@@ -5,9 +5,9 @@ using LasseVK.Extensions.Hosting.ConsoleApplications.Attributes;
 
 namespace ConsoleSandbox.Commands;
 
-[CommandLineCommand("list")]
+[ConsoleCommand("list")]
 [Description("Lists all files")]
-public class ListCommand : ICommandLineApplication
+public class ListCommand : IConsoleApplication
 {
     [Option("v")]
     [Option("verbose")]

--- a/sandboxes/ConsoleSandbox/Program.cs
+++ b/sandboxes/ConsoleSandbox/Program.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Hosting;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 builder.RelocateConfigurationFiles<Program>();
-builder.AddCommandLineCommands<Program>();
+builder.AddConsoleCommands<Program>();
 
 IHost host = builder.Build();
 await host.RunAsync();

--- a/src/LasseVK.Extensions.Hosting.ConsoleApplications/Attributes/ConsoleCommandAttribute.cs
+++ b/src/LasseVK.Extensions.Hosting.ConsoleApplications/Attributes/ConsoleCommandAttribute.cs
@@ -1,9 +1,9 @@
 namespace LasseVK.Extensions.Hosting.ConsoleApplications.Attributes;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class CommandLineCommandAttribute : Attribute
+public class ConsoleCommandAttribute : Attribute
 {
-    public CommandLineCommandAttribute(string name)
+    public ConsoleCommandAttribute(string name)
     {
         Name = name;
     }

--- a/src/LasseVK.Extensions.Hosting.ConsoleApplications/GlobalCommands/HelpCommand.cs
+++ b/src/LasseVK.Extensions.Hosting.ConsoleApplications/GlobalCommands/HelpCommand.cs
@@ -4,12 +4,12 @@ using LasseVK.Extensions.Hosting.ConsoleApplications.Attributes;
 
 namespace LasseVK.Extensions.Hosting.ConsoleApplications.GlobalCommands;
 
-[CommandLineCommand("help")]
+[ConsoleCommand("help")]
 [Description("Shows help for the application or for a specific command.\nUse 'help' to show a list of available commands.\nUse 'help <command>' to show help for a specific command.")]
-internal class HelpCommand : ICommandLineApplication
+internal class HelpCommand : IConsoleApplication
 {
     private readonly IServiceProvider _services;
-    private readonly Dictionary<string, Func<IServiceProvider, ICommandLineApplication>> _commands = new(StringComparer.InvariantCultureIgnoreCase);
+    private readonly Dictionary<string, Func<IServiceProvider, IConsoleApplication>> _commands = new(StringComparer.InvariantCultureIgnoreCase);
 
     public HelpCommand(IServiceProvider services)
     {
@@ -31,13 +31,13 @@ internal class HelpCommand : ICommandLineApplication
             return 0;
         }
 
-        if (!_commands.TryGetValue(CommandName, out Func<IServiceProvider, ICommandLineApplication>? commandFactory))
+        if (!_commands.TryGetValue(CommandName, out Func<IServiceProvider, IConsoleApplication>? commandFactory))
         {
             await Console.Error.WriteLineAsync($"error: unknown command {CommandName}");
             return 1;
         }
 
-        ICommandLineApplication command = commandFactory(_services);
+        IConsoleApplication command = commandFactory(_services);
         foreach (string line in CommandLineHelp.GetCommandHelp(command, CommandName.ToUpperInvariant()))
         {
             Console.WriteLine(line);
@@ -59,9 +59,9 @@ internal class HelpCommand : ICommandLineApplication
         Console.WriteLine("Use 'help <command>' for more information on a specific command.");
     }
 
-    public void AddCommands(Dictionary<string, Func<IServiceProvider, ICommandLineApplication>> commands)
+    public void AddCommands(Dictionary<string, Func<IServiceProvider, IConsoleApplication>> commands)
     {
-        foreach (KeyValuePair<string, Func<IServiceProvider, ICommandLineApplication>> kvp in commands)
+        foreach (KeyValuePair<string, Func<IServiceProvider, IConsoleApplication>> kvp in commands)
         {
             _commands.Add(kvp.Key, kvp.Value);
         }

--- a/src/LasseVK.Extensions.Hosting.ConsoleApplications/HostApplicationBuilderExtensions.cs
+++ b/src/LasseVK.Extensions.Hosting.ConsoleApplications/HostApplicationBuilderExtensions.cs
@@ -9,32 +9,32 @@ namespace LasseVK.Extensions.Hosting.ConsoleApplications;
 
 public static class HostApplicationBuilderExtensions
 {
-    public static IHostApplicationBuilder AddCommandLineApplication<T>(this IHostApplicationBuilder builder, Action<T>? configure = null)
-        where T : class, ICommandLineApplication
+    public static IHostApplicationBuilder AddConsoleApplication<T>(this IHostApplicationBuilder builder, Action<T>? configure = null)
+        where T : class, IConsoleApplication
     {
-        builder.Services.AddHostedService<RunCommandLineApplicationBackgroundService>();
-        builder.Services.Configure<RunCommandLineApplicationBackgroundServiceOptions>(options => options.SetConsoleApplication(configure));
+        builder.Services.AddHostedService<ConsoleApplicationHostedService>();
+        builder.Services.Configure<ConsoleApplicationHostedServiceOptions>(options => options.SetConsoleApplication(configure));
         return builder;
     }
 
-    public static IHostApplicationBuilder AddCommandLineCommand<T>(this IHostApplicationBuilder builder, Action<T>? configure = null)
-        where T : class, ICommandLineApplication
+    public static IHostApplicationBuilder AddConsoleCommand<T>(this IHostApplicationBuilder builder, Action<T>? configure = null)
+        where T : class, IConsoleApplication
     {
-        builder.Services.AddHostedService<RunCommandLineApplicationBackgroundService>();
-        builder.Services.Configure<RunCommandLineApplicationBackgroundServiceOptions>(options => options.AddCommand(configure));
+        builder.Services.AddHostedService<ConsoleApplicationHostedService>();
+        builder.Services.Configure<ConsoleApplicationHostedServiceOptions>(options => options.AddCommand(configure));
         return builder;
     }
 
-    public static IHostApplicationBuilder AddCommandLineCommands<TProgram>(this IHostApplicationBuilder builder)
+    public static IHostApplicationBuilder AddConsoleCommands<TProgram>(this IHostApplicationBuilder builder)
         where TProgram : class
     {
-        builder.Services.AddHostedService<RunCommandLineApplicationBackgroundService>();
+        builder.Services.AddHostedService<ConsoleApplicationHostedService>();
 
         foreach (Type type in typeof(TProgram).Assembly.GetTypes())
         {
-            if (type.IsAssignableTo(typeof(ICommandLineApplication)) && !type.IsAbstract)
+            if (type.IsAssignableTo(typeof(IConsoleApplication)) && !type.IsAbstract)
             {
-                builder.Services.Configure<RunCommandLineApplicationBackgroundServiceOptions>(options => options.AddCommand(type));
+                builder.Services.Configure<ConsoleApplicationHostedServiceOptions>(options => options.AddCommand(type));
             }
         }
 

--- a/src/LasseVK.Extensions.Hosting.ConsoleApplications/ICommandLineApplication.cs
+++ b/src/LasseVK.Extensions.Hosting.ConsoleApplications/ICommandLineApplication.cs
@@ -1,6 +1,0 @@
-﻿namespace LasseVK.Extensions.Hosting.ConsoleApplications;
-
-public interface ICommandLineApplication
-{
-    Task<int> RunAsync(CancellationToken cancellationToken);
-}

--- a/src/LasseVK.Extensions.Hosting.ConsoleApplications/IConsoleApplication.cs
+++ b/src/LasseVK.Extensions.Hosting.ConsoleApplications/IConsoleApplication.cs
@@ -1,0 +1,6 @@
+namespace LasseVK.Extensions.Hosting.ConsoleApplications;
+
+public interface IConsoleApplication
+{
+    Task<int> RunAsync(CancellationToken cancellationToken);
+}

--- a/src/LasseVK.Extensions.Hosting.ConsoleApplications/Internal/ConsoleApplicationHostedService.cs
+++ b/src/LasseVK.Extensions.Hosting.ConsoleApplications/Internal/ConsoleApplicationHostedService.cs
@@ -4,14 +4,14 @@ using Microsoft.Extensions.Options;
 
 namespace LasseVK.Extensions.Hosting.ConsoleApplications.Internal;
 
-internal class RunCommandLineApplicationBackgroundService : BackgroundService
+internal class ConsoleApplicationHostedService : BackgroundService
 {
-    private readonly IOptions<RunCommandLineApplicationBackgroundServiceOptions> _options;
+    private readonly IOptions<ConsoleApplicationHostedServiceOptions> _options;
     private readonly IServiceProvider _services;
-    private readonly ILogger<RunCommandLineApplicationBackgroundService> _logger;
+    private readonly ILogger<ConsoleApplicationHostedService> _logger;
     private readonly IHostApplicationLifetime _hostApplicationLifetime;
 
-    public RunCommandLineApplicationBackgroundService(IOptions<RunCommandLineApplicationBackgroundServiceOptions> options, IServiceProvider services, ILogger<RunCommandLineApplicationBackgroundService> logger,
+    public ConsoleApplicationHostedService(IOptions<ConsoleApplicationHostedServiceOptions> options, IServiceProvider services, ILogger<ConsoleApplicationHostedService> logger,
         IHostApplicationLifetime  hostApplicationLifetime)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -22,7 +22,7 @@ internal class RunCommandLineApplicationBackgroundService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        ICommandLineApplication? consoleApplication = _options.Value.GetConsoleApplication(_services);
+        IConsoleApplication? consoleApplication = _options.Value.GetConsoleApplication(_services);
 
         if (consoleApplication is null)
         {

--- a/src/LasseVK.Extensions.Hosting.ConsoleApplications/Internal/ConsoleApplicationHostedServiceOptions.cs
+++ b/src/LasseVK.Extensions.Hosting.ConsoleApplications/Internal/ConsoleApplicationHostedServiceOptions.cs
@@ -7,13 +7,13 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace LasseVK.Extensions.Hosting.ConsoleApplications.Internal;
 
-internal class RunCommandLineApplicationBackgroundServiceOptions
+internal class ConsoleApplicationHostedServiceOptions
 {
-    private Func<IServiceProvider, ICommandLineApplication>? _consoleApplicationFactory;
-    private Dictionary<string, Func<IServiceProvider, ICommandLineApplication>> _commands = new(StringComparer.InvariantCultureIgnoreCase);
+    private Func<IServiceProvider, IConsoleApplication>? _consoleApplicationFactory;
+    private Dictionary<string, Func<IServiceProvider, IConsoleApplication>> _commands = new(StringComparer.InvariantCultureIgnoreCase);
 
-    public RunCommandLineApplicationBackgroundServiceOptions SetConsoleApplication<T>(Action<T>? configure)
-        where T : ICommandLineApplication
+    public ConsoleApplicationHostedServiceOptions SetConsoleApplication<T>(Action<T>? configure)
+        where T : IConsoleApplication
     {
         if (_consoleApplicationFactory != null)
         {
@@ -30,7 +30,7 @@ internal class RunCommandLineApplicationBackgroundServiceOptions
         return this;
     }
 
-    public ICommandLineApplication? GetConsoleApplication(IServiceProvider services)
+    public IConsoleApplication? GetConsoleApplication(IServiceProvider services)
     {
         if (_consoleApplicationFactory != null)
         {
@@ -42,8 +42,8 @@ internal class RunCommandLineApplicationBackgroundServiceOptions
             throw new InvalidOperationException("No console application configured.");
         }
 
-        RunCommandLineCommandConsoleApplication application = ActivatorUtilities.CreateInstance<RunCommandLineCommandConsoleApplication>(services);
-        application.AddCommands(new Dictionary<string, Func<IServiceProvider, ICommandLineApplication>>
+        ConsoleCommandDispatcher application = ActivatorUtilities.CreateInstance<ConsoleCommandDispatcher>(services);
+        application.AddCommands(new Dictionary<string, Func<IServiceProvider, IConsoleApplication>>
         {
             ["help"] = srv => ActivatorUtilities.CreateInstance<HelpCommand>(srv),
         });
@@ -52,9 +52,9 @@ internal class RunCommandLineApplicationBackgroundServiceOptions
     }
 
     public void AddCommand<T>(Action<T>? configure)
-        where T : class, ICommandLineApplication
+        where T : class, IConsoleApplication
     {
-        string name = typeof(T).GetCustomAttribute<CommandLineCommandAttribute>()?.Name ?? typeof(T).Name.Replace("Command", "");;
+        string name = typeof(T).GetCustomAttribute<ConsoleCommandAttribute>()?.Name ?? typeof(T).Name.Replace("Command", "");;
 
         _commands.Add(name, services =>
         {
@@ -66,8 +66,8 @@ internal class RunCommandLineApplicationBackgroundServiceOptions
 
     public void AddCommand(Type type)
     {
-        string name = type.GetCustomAttribute<CommandLineCommandAttribute>()?.Name ?? type.Name.Replace("Command", "");;
+        string name = type.GetCustomAttribute<ConsoleCommandAttribute>()?.Name ?? type.Name.Replace("Command", "");;
 
-        _commands.Add(name, services => (ICommandLineApplication)ActivatorUtilities.CreateInstance(services, type));
+        _commands.Add(name, services => (IConsoleApplication)ActivatorUtilities.CreateInstance(services, type));
     }
 }

--- a/src/LasseVK.Extensions.Hosting.ConsoleApplications/Internal/ConsoleCommandDispatcher.cs
+++ b/src/LasseVK.Extensions.Hosting.ConsoleApplications/Internal/ConsoleCommandDispatcher.cs
@@ -5,12 +5,12 @@ using LasseVK.Extensions.Hosting.ConsoleApplications.GlobalCommands;
 
 namespace LasseVK.Extensions.Hosting.ConsoleApplications.Internal;
 
-internal class RunCommandLineCommandConsoleApplication : ICommandLineApplication
+internal class ConsoleCommandDispatcher : IConsoleApplication
 {
     private readonly IServiceProvider _services;
-    private readonly Dictionary<string, Func<IServiceProvider, ICommandLineApplication>> _commands = new(StringComparer.InvariantCultureIgnoreCase);
+    private readonly Dictionary<string, Func<IServiceProvider, IConsoleApplication>> _commands = new(StringComparer.InvariantCultureIgnoreCase);
 
-    public RunCommandLineCommandConsoleApplication(IServiceProvider services)
+    public ConsoleCommandDispatcher(IServiceProvider services)
     {
         _services = services ?? throw new ArgumentNullException(nameof(services));
     }
@@ -26,9 +26,9 @@ internal class RunCommandLineCommandConsoleApplication : ICommandLineApplication
     [Description("Arguments to pass to the command")]
     public List<string> ArgumentsToCommand { get; } = [];
 
-    public void AddCommands(Dictionary<string, Func<IServiceProvider, ICommandLineApplication>> commands)
+    public void AddCommands(Dictionary<string, Func<IServiceProvider, IConsoleApplication>> commands)
     {
-        foreach (KeyValuePair<string, Func<IServiceProvider, ICommandLineApplication>> kvp in commands)
+        foreach (KeyValuePair<string, Func<IServiceProvider, IConsoleApplication>> kvp in commands)
         {
             _commands.Add(kvp.Key, kvp.Value);
         }
@@ -44,13 +44,13 @@ internal class RunCommandLineCommandConsoleApplication : ICommandLineApplication
             return 1;
         }
 
-        if (!_commands.TryGetValue(CommandName, out Func<IServiceProvider, ICommandLineApplication>? commandFactory))
+        if (!_commands.TryGetValue(CommandName, out Func<IServiceProvider, IConsoleApplication>? commandFactory))
         {
             await Console.Error.WriteLineAsync($"error: unknown command {CommandName}");
             return 1;
         }
 
-        ICommandLineApplication command = commandFactory(_services);
+        IConsoleApplication command = commandFactory(_services);
         CommandLineArgumentsInjector.Inject(ArgumentsToCommand.ToArray(), command);
         if (command is HelpCommand help)
         {


### PR DESCRIPTION
Major changes:
- ICommandLineApplication → IConsoleApplication
- RunCommandLineApplicationBackgroundService → ConsoleApplicationHostedService
- RunCommandLineApplicationBackgroundServiceOptions → ConsoleApplicationHostedServiceOptions
- RunCommandLineCommandConsoleApplication → ConsoleCommandDispatcher
- CommandLineCommandAttribute → ConsoleCommandAttribute
- AddCommandLineApplication/Command/Commands → AddConsoleApplication/Command/Commands

This unifies the naming around 'Console' to match the project name and dramatically shortens the verbose service class names while maintaining clarity. All functionality preserved and verified working.